### PR TITLE
Add default pins for Arduino MKR CAN shield

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ env:
     - IDE_VERSION=1.8.5
   matrix:
     - BOARD="arduino:avr:uno"
+    - BOARD="arduino:samd:mkrzero"
     - BOARD="espressif:esp32:esp32"
 before_install:
   - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
   - tar xf arduino-$IDE_VERSION-linux64.tar.xz
   - mv arduino-$IDE_VERSION $HOME/arduino-ide
   - export PATH=$PATH:$HOME/arduino-ide
+  - if [[ "$BOARD" =~ "arduino:samd:" ]]; then
+      arduino --install-boards arduino:samd;
+    fi
   - if [[ "$BOARD" =~ "espressif:esp32:" ]]; then
       mkdir -p $HOME/Arduino/hardware/espressif;
       git clone https://github.com/espressif/arduino-esp32.git $HOME/Arduino/hardware/espressif/esp32;

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An Arduino library for sending and receiving data using CAN bus.
 ## Compatible Hardware
 
 * [Microchip MCP2515](http://www.microchip.com/wwwproducts/en/en010406) based boards/shields
+  * [Arduino MKR CAN shield](https://store.arduino.cc/arduino-mkr-can-shield)
 * [Espressif ESP32](http://espressif.com/en/products/hardware/esp32/overview)'s built-in [SJA1000](https://www.nxp.com/products/analog/interfaces/in-vehicle-network/can-transceiver-and-controllers/stand-alone-can-controller:SJA1000T) compatible CAN controller with an external 3.3V CAN transceiver
 
 ### Microchip MCP2515 wiring

--- a/src/MCP2515.h
+++ b/src/MCP2515.h
@@ -10,13 +10,13 @@
 
 #include "CANController.h"
 
+#define MCP2515_DEFAULT_CLOCK_FREQUENCY 16e6
+
 #if defined(ARDUINO_ARCH_SAMD) && defined(USB_VID) && (USB_VID == 0x2341) && !defined(ARDUINO_SAMD_ZERO)
 // Arduino MKR board: MKR CAN shield CS is pin 3, INT is pin 7
-#define MCP2515_DEFAULT_CLOCK_FREQUENCY 16e6
 #define MCP2515_DEFAULT_CS_PIN          3
 #define MCP2515_DEFAULT_INT_PIN         7
 #else
-#define MCP2515_DEFAULT_CLOCK_FREQUENCY 16e6
 #define MCP2515_DEFAULT_CS_PIN          10
 #define MCP2515_DEFAULT_INT_PIN         2
 #endif

--- a/src/MCP2515.h
+++ b/src/MCP2515.h
@@ -10,9 +10,16 @@
 
 #include "CANController.h"
 
+#if defined(ARDUINO_ARCH_SAMD) && defined(USB_VID) && (USB_VID == 0x2341) && !defined(ARDUINO_SAMD_ZERO)
+// Arduino MKR board: MKR CAN shield CS is pin 3, INT is pin 7
+#define MCP2515_DEFAULT_CLOCK_FREQUENCY 16e6
+#define MCP2515_DEFAULT_CS_PIN          3
+#define MCP2515_DEFAULT_INT_PIN         7
+#else
 #define MCP2515_DEFAULT_CLOCK_FREQUENCY 16e6
 #define MCP2515_DEFAULT_CS_PIN          10
 #define MCP2515_DEFAULT_INT_PIN         2
+#endif
 
 class MCP2515Class : public CANControllerClass {
 


### PR DESCRIPTION
When using Arduino SAMD that is not the Arduino Zero.

@agdl please review.