### PR TITLE
fixing reception of packets with DLC=0

### DIFF
--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -20,7 +20,7 @@ void loop() {
   // try to parse packet
   int packetSize = CAN.parsePacket();
 
-  if (packetSize) {
+  if (packetSize >= 0) {
     // received a packet
     Serial.print("Received ");
 

--- a/src/CANController.cpp
+++ b/src/CANController.cpp
@@ -109,7 +109,7 @@ int CANControllerClass::endPacket()
 
 int CANControllerClass::parsePacket()
 {
-  return 0;
+  return -1;
 }
 
 long CANControllerClass::packetId()

--- a/src/ESP32SJA1000.cpp
+++ b/src/ESP32SJA1000.cpp
@@ -219,7 +219,7 @@ int ESP32SJA1000Class::parsePacket()
 {
   if ((readRegister(REG_SR) & 0x01) != 0x01) {
     // no packet
-    return 0;
+    return -1;
   }
 
   _rxExtended = (readRegister(REG_SFF) & 0x80) ? true : false;

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -225,7 +225,7 @@ int MCP2515Class::parsePacket()
     _rxExtended = false;
     _rxRtr = false;
     _rxLength = 0;
-    return 0;
+    return -1;
   }
 
   _rxExtended = (readRegister(REG_RXBnSIDL(n)) & FLAG_IDE) ? true : false;


### PR DESCRIPTION
Packets with DLC=0 are reported in the same way as if no packet has been received. As the CAN standard allows packets with DLC=0, I have changed the behaviour of parsePacket to return -1 if no packet has been received and the packet length otherwise.