### PR TITLE
Fix MCP2515 observe and document it

### DIFF
--- a/API.md
+++ b/API.md
@@ -249,6 +249,15 @@ Returns `1` on success, `0` on failure.
 
 ## Other modes
 
+### Listen-Only mode
+
+Put the CAN controller in Listen-Only mode, this mode provides a means to receive all messages (including messages with errors).
+Listen-Only mode is a silent mode, meaning no messages will be transmitted while in this mode (including error flags or acknowledge signals).
+
+```arduino
+CAN.observe();
+```
+
 ### Loopback mode
 
 Put the CAN controller in loopback mode, any outgoing packets will also be received.
@@ -265,7 +274,7 @@ Put the CAN contoller in sleep mode.
 CAN.sleep();
 ```
 
-Wake up the CAN contoller if it was previously in sleep mode.
+Wake up the CAN contoller, if it was previously in sleep mode. This will put the CAN controller into normal operation mode.
 
 ```arduino
 CAN.wakeup();

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -353,8 +353,8 @@ int MCP2515Class::filterExtended(long id, long mask)
 
 int MCP2515Class::observe()
 {
-  writeRegister(REG_CANCTRL, 0x80);
-  if (readRegister(REG_CANCTRL) != 0x80) {
+  writeRegister(REG_CANCTRL, 0x60);
+  if (readRegister(REG_CANCTRL) != 0x60) {
     return 0;
   }
 


### PR DESCRIPTION
This PR fixes the MCP2515 observe method. Previously `configuration mode` was set (`0x80`), however according to the datasheet of MCP2515, the `listen-only mode` is `0x60`.

The method `observe` is added to `API.md` for documentation.

Fixes #40.