### PR TITLE
Fix CAN.begin() for MCP2515 with 8 MHz quartz by increasing the delay

### DIFF
--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -433,7 +433,15 @@ void MCP2515Class::reset()
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
 
-  delayMicroseconds(10);
+  // From the data sheet:
+  // The OST keeps the device in a Reset state for 128 OSC1 clock cycles after
+  // the occurrence of a Power-on Reset, SPI Reset, after the assertion of the
+  // RESET pin, and after a wake-up from Sleep mode. It should be noted that no
+  // SPI protocol operations should be attempted until after the OST has
+  // expired.
+  // We sleep for 160 cycles to match the old behavior with 16 MHz quartz, and
+  // to be on the safe side for 8 MHz devices.
+  delayMicroseconds(ceil(160 * 1000000.0 / _clockFrequency));
 }
 
 void MCP2515Class::handleInterrupt()


### PR DESCRIPTION
Hi!

I bought a few MCP2515 from Amazon and they all came with 8 MHz quartz crystal.
Whenever I called `CAN.begin()`, it would return 0.
I was sure I set all the configuration parameters correctly before calling it.

It took me some time to debug, but then I started reading the datasheet [1] and found section 8.1 that says
```
8.1 Oscillator Start-up Timer
The MCP2515 utilizes an Oscillator Start-up Timer
(OST) that holds the MCP2515 in Reset to ensure that
the oscillator has stabilized before the internal state
machine begins to operate. The OST keeps the device
in a Reset state for 128 OSC1 clock cycles after the
occurrence of a Power-on Reset, SPI Reset, after the
assertion of the RESET pin, and after a wake-up from
Sleep mode. It should be noted that no SPI protocol
operations should be attempted until after the OST has
expired.
```

There is a `delayMicroseconds(10);` inside `MCP2515Class::reset()`, but some quick math reveals that 128 clock cycles of a 8 MHz clock is 16 microseconds. Indeed, changing the value from 10 to 16 makes `CAN.begin()` work for me.

[1] http://ww1.microchip.com/downloads/en/DeviceDoc/MCP2515-Stand-Alone-CAN-Controller-with-SPI-20001801J.pdf