### PR TITLE
reception of empty packets with and without callback

### DIFF
--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -20,7 +20,7 @@ void loop() {
   // try to parse packet
   int packetSize = CAN.parsePacket();
 
-  if (packetSize) {
+  if (packetSize || CAN. packetId() != -1) {
     // received a packet
     Serial.print("Received ");
 

--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -20,7 +20,7 @@ void loop() {
   // try to parse packet
   int packetSize = CAN.parsePacket();
 
-  if (packetSize || CAN. packetId() != -1) {
+  if (packetSize || CAN.packetId() != -1) {
     // received a packet
     Serial.print("Received ");
 

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -442,7 +442,7 @@ void MCP2515Class::handleInterrupt()
     return;
   }
 
-  while (parsePacket() || _rxId() != -1) {
+  while (parsePacket() || _rxId != -1) {
     _onReceive(available());
   }
 }

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -442,7 +442,7 @@ void MCP2515Class::handleInterrupt()
     return;
   }
 
-  while (parsePacket()) {
+  while (parsePacket() || _rxId() != -1) {
     _onReceive(available());
   }
 }


### PR DESCRIPTION
The current example of CANReceiver and CANReceiverCallback doesn't recognize empty packets. This commit fixes this issue. I only tested on MCP2515; therefore, not sure if any change is also needed on ESP32SJA1000 class.