### PR TITLE
MCP2515: fix observe() method.

### DIFF
--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -353,8 +353,8 @@ int MCP2515Class::filterExtended(long id, long mask)
 
 int MCP2515Class::observe()
 {
-  writeRegister(REG_CANCTRL, 0x80);
-  if (readRegister(REG_CANCTRL) != 0x80) {
+  writeRegister(REG_CANCTRL, 0x60);
+  if (readRegister(REG_CANCTRL) != 0x60) {
     return 0;
   }
 


### PR DESCRIPTION
Fixes the observe() method to set the "listen only mode" bit in the control register instead of the "configuration mode" bit.