### PR TITLE
Fix `attachInterrupt` link to Arduino docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An Arduino library for sending and receiving data using CAN bus.
 | INT | 2 |
 
 
-`CS` and `INT` pins can be changed by using `CAN.setPins(cs, irq)`. `INT` pin is optional, it is only needed for receive callback mode. If `INT` pin is used, it **must** be interrupt capable via [`attachInterrupt(...)`](https://www.arduino.cc/en/Reference/AttachInterrupt).
+`CS` and `INT` pins can be changed by using `CAN.setPins(cs, irq)`. `INT` pin is optional, it is only needed for receive callback mode. If `INT` pin is used, it **must** be interrupt capable via [`attachInterrupt(...)`](https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/).
 
 **NOTE**: Logic level converters must be used for boards which operate at 3.3V.
 


### PR DESCRIPTION
Small fix; the URL currently used is broken.