### PR TITLE
Set correct bits for sleep mode

### DIFF
--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -375,8 +375,8 @@ int MCP2515Class::loopback()
 
 int MCP2515Class::sleep()
 {
-  writeRegister(REG_CANCTRL, 0x01);
-  if (readRegister(REG_CANCTRL) != 0x01) {
+  writeRegister(REG_CANCTRL, 0x20);
+  if (readRegister(REG_CANCTRL) != 0x20) {
     return 0;
   }
 


### PR DESCRIPTION
I believe the wrong bits were set. See page 60 in the data sheet. ![image](https://github.com/sandeepmistry/arduino-CAN/assets/80832451/829e16eb-9344-4946-a6ab-1fe26d31b4e6)
