### PR TITLE
Call _onreceive on correct MCP2515 class instance

### DIFF
--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -56,12 +56,12 @@
 #define FLAG_RXM1                  0x40
 
 static const MCP2515Class::INTVector MCP2515Class::_vectors[6] = {
-  MCP2515Class::onInterruptINT0,
-  MCP2515Class::onInterruptINT1,
-  MCP2515Class::onInterruptINT2,
-  MCP2515Class::onInterruptINT3,
-  MCP2515Class::onInterruptINT4,
-  MCP2515Class::onInterruptINT5
+  MCP2515Class::onInterrupt0,
+  MCP2515Class::onInterrupt1,
+  MCP2515Class::onInterrupt2,
+  MCP2515Class::onInterrupt3,
+  MCP2515Class::onInterrupt4,
+  MCP2515Class::onInterrupt5
 };
 
 static MCP2515Class::INTHandler MCP2515Class::_instances[6];
@@ -280,7 +280,7 @@ void MCP2515Class::onReceive(void(*callback)(int))
   
   if (callback) {
     SPI.usingInterrupt(inum);
-    if (inum >= 0 && inum < sizeof(_vectors)) {
+    if (inum >= 0 && inum < (sizeof(_vectors) / sizeof(_vectors[0]))) {
       _instances[inum] = this;
       attachInterrupt(inum, _vectors[inum], LOW);
     } else {
@@ -509,40 +509,34 @@ void MCP2515Class::onInterrupt()
   CAN.handleInterrupt();
 }
 
-void MCP2515Class::onInterrupt(uint8_t irq)
+void MCP2515Class::onInterrupt0()
 {
-  INTHandler instance = _instances[irq];
-  if (instance) instance->handleInterrupt();
+  _instances[0]->handleInterrupt();
 }
 
-void MCP2515Class::onInterruptINT0()
+void MCP2515Class::onInterrupt1()
 {
-  onInterrupt(0);
+  _instances[1]->handleInterrupt();
 }
 
-void MCP2515Class::onInterruptINT1()
+void MCP2515Class::onInterrupt2()
 {
-  onInterrupt(1);
+  _instances[2]->handleInterrupt();
 }
 
-void MCP2515Class::onInterruptINT2()
+void MCP2515Class::onInterrupt3()
 {
-  onInterrupt(2);
+  _instances[3]->handleInterrupt();
 }
 
-void MCP2515Class::onInterruptINT3()
+void MCP2515Class::onInterrupt4()
 {
-  onInterrupt(3);
+  _instances[4]->handleInterrupt();
 }
 
-void MCP2515Class::onInterruptINT4()
+void MCP2515Class::onInterrupt5()
 {
-  onInterrupt(4);
-}
-
-void MCP2515Class::onInterruptINT5()
-{
-  onInterrupt(5);
+  _instances[5]->handleInterrupt();
 }
 
 MCP2515Class CAN;

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -55,6 +55,16 @@
 #define FLAG_RXM0                  0x20
 #define FLAG_RXM1                  0x40
 
+static const MCP2515Class::INTVector MCP2515Class::_vectors[6] = {
+  MCP2515Class::onInterruptINT0,
+  MCP2515Class::onInterruptINT1,
+  MCP2515Class::onInterruptINT2,
+  MCP2515Class::onInterruptINT3,
+  MCP2515Class::onInterruptINT4,
+  MCP2515Class::onInterruptINT5
+};
+
+static MCP2515Class::INTHandler MCP2515Class::_instances[6];
 
 MCP2515Class::MCP2515Class() :
   CANControllerClass(),
@@ -266,13 +276,20 @@ void MCP2515Class::onReceive(void(*callback)(int))
 
   pinMode(_intPin, INPUT);
 
+  int8_t inum = digitalPinToInterrupt(_intPin);
+  
   if (callback) {
-    SPI.usingInterrupt(digitalPinToInterrupt(_intPin));
-    attachInterrupt(digitalPinToInterrupt(_intPin), MCP2515Class::onInterrupt, LOW);
+    SPI.usingInterrupt(inum);
+    if (inum >= 0 && inum < sizeof(_vectors)) {
+      _instances[inum] = this;
+      attachInterrupt(inum, _vectors[inum], LOW);
+    } else {
+      attachInterrupt(inum, MCP2515Class::onInterrupt, LOW);
+    }
   } else {
-    detachInterrupt(digitalPinToInterrupt(_intPin));
+    detachInterrupt(inum);
 #ifdef SPI_HAS_NOTUSINGINTERRUPT
-    SPI.notUsingInterrupt(digitalPinToInterrupt(_intPin));
+    SPI.notUsingInterrupt(inum);
 #endif
   }
 }
@@ -445,7 +462,7 @@ void MCP2515Class::handleInterrupt()
   }
 
   while (parsePacket() || _rxId != -1) {
-    _onReceive(available());
+    if (_onReceive) _onReceive(available());
   }
 }
 
@@ -490,6 +507,42 @@ void MCP2515Class::writeRegister(uint8_t address, uint8_t value)
 void MCP2515Class::onInterrupt()
 {
   CAN.handleInterrupt();
+}
+
+void MCP2515Class::onInterrupt(uint8_t irq)
+{
+  INTHandler instance = _instances[irq];
+  if (instance) instance->handleInterrupt();
+}
+
+void MCP2515Class::onInterruptINT0()
+{
+  onInterrupt(0);
+}
+
+void MCP2515Class::onInterruptINT1()
+{
+  onInterrupt(1);
+}
+
+void MCP2515Class::onInterruptINT2()
+{
+  onInterrupt(2);
+}
+
+void MCP2515Class::onInterruptINT3()
+{
+  onInterrupt(3);
+}
+
+void MCP2515Class::onInterruptINT4()
+{
+  onInterrupt(4);
+}
+
+void MCP2515Class::onInterruptINT5()
+{
+  onInterrupt(5);
 }
 
 MCP2515Class CAN;

--- a/src/MCP2515.h
+++ b/src/MCP2515.h
@@ -62,12 +62,25 @@ private:
   void writeRegister(uint8_t address, uint8_t value);
 
   static void onInterrupt();
+  static void onInterrupt(uint8_t irq);
+  static void onInterruptINT0();
+  static void onInterruptINT1();
+  static void onInterruptINT2();
+  static void onInterruptINT3();
+  static void onInterruptINT4();
+  static void onInterruptINT5();
 
 private:
   SPISettings _spiSettings;
   int _csPin;
   int _intPin;
   long _clockFrequency;
+
+  typedef void (*INTVector)(void);
+  typedef MCP2515Class* INTHandler;
+
+  static const INTVector _vectors[6];
+  static INTHandler _instances[6];
 };
 
 extern MCP2515Class CAN;

--- a/src/MCP2515.h
+++ b/src/MCP2515.h
@@ -62,13 +62,12 @@ private:
   void writeRegister(uint8_t address, uint8_t value);
 
   static void onInterrupt();
-  static void onInterrupt(uint8_t irq);
-  static void onInterruptINT0();
-  static void onInterruptINT1();
-  static void onInterruptINT2();
-  static void onInterruptINT3();
-  static void onInterruptINT4();
-  static void onInterruptINT5();
+  static void onInterrupt0();
+  static void onInterrupt1();
+  static void onInterrupt2();
+  static void onInterrupt3();
+  static void onInterrupt4();
+  static void onInterrupt5();
 
 private:
   SPISettings _spiSettings;


### PR DESCRIPTION
When this library is used with multiple MCP2515, MCP2515Class::handleInterrupt() is called via the static function MCP2515Class::onInterrupt().  This always calls the _onreceive function that was set on the main CAN class instance.

Instead it should call MCP2515Class::handleInterrupt on the class instance that originally attached to the corresponding interrupt.

This pull request makes it possible to have multiple MCP2515 interfaces, each on a separate interrupt, and have them receive CAN packets successfully via MCP2515Class::onReceive(...).