### PR TITLE
Set the delay up a tad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/MCP2515.cpp
+++ b/src/MCP2515.cpp
@@ -435,7 +435,7 @@ void MCP2515Class::reset()
   digitalWrite(_csPin, HIGH);
   SPI.endTransaction();
 
-  delayMicroseconds(10);
+  delayMicroseconds(20);	// Bumped from 10 to 20. 10 didn't work, 20 does. -jim lee
 }
 
 void MCP2515Class::handleInterrupt()


### PR DESCRIPTION
The delay on reset from 10 to 20 micros. Works with 20 doesn't at 10. So I forked this to have this change.

Why doesn't it work with 10 micros? Possibly because I'm running it on a Teensy at 72 MHz? I donno. It's my only guess. But 20 micros worked fine. And this is only called one time during setup().